### PR TITLE
change output symbol based on exit code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pip-upgrade"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "colored",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "pip-upgrade"
 readme = "README.md"
 repository = "https://github.com/Araxeus/pip-upgrade"
-version = "0.1.1"
+version = "0.2.0"
 
 [[bin]]
 name = "pip-upgrade"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,14 @@ pub fn update_all() -> Result<()> {
             .args(["install", "--upgrade", &formatted.name])
             .output()?;
 
-        // print last line of output
         let stdout = String::from_utf8(output.stdout).unwrap_or_default();
-        spinner.success(stdout.lines().last().unwrap_or_default().trim());
+        let stdout_output = stdout.lines().last().unwrap_or_default().trim();
+
+        match output.status.code().unwrap_or(1) {
+            0 => spinner.success(stdout_output),
+            1 => spinner.fail(stdout_output),
+            _ => spinner.warn(stdout_output),
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Will now properly show an error/warning icon if process didn't exit with code `0`