### PR TITLE
use `--not-required`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ fn get_outdated() -> Result<Vec<Package>> {
     );
     // get the json output
     let output = Command::new("pip")
-        .args(["list", "--outdated", "--format=json"])
+        .args(["list", "--outdated", "--not-required", "--format=json"])
         .output()?;
 
     // parse the json output


### PR DESCRIPTION
use the [--not-required](https://pip.pypa.io/en/stable/cli/pip_list/#cmdoption-not-required) pip flag